### PR TITLE
Change Makefile to check for build blocking directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ iTerm2/:
 
 reset: iTerm2/
 	cd iTerm2 && git reset --hard 0232ba490ba855ca34bc23446bb1e6e13d7cfab9
+	if [ -d iTerm2/bin  ] ; \
+		then \
+			rm -rf iTerm2/bin ; \
+	fi;
+	if [ -d iTerm.app/iTerm2.app ] ; \
+		then \
+			rm -rf iTerm.app/iTerm2.app ; \
+	fi;
 
 patch: reset
 	patch iTerm2/sources/PseudoTerminal.m < borderless.patch


### PR DESCRIPTION
## Purpose
- Currently, if you build with `make build` then change some source and want to build again or even just run `make reset` and `make build` right after, the build fails in two places.
- Closes Issue #2 
## Changes

Add two if statements in Makefile under reset that check for the directories and remove them if they exist. They will be remade in `make build` so nothing is really lost. 
## Side effects
- The text printed to stdin after running `make reset` now is poorly formatted
- If this is not what `reset` is for then this could possible be extracted to something like `make clean` instead
